### PR TITLE
Repo refresh: infra + docs v0.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,13 @@
+name: Bug report
+description: Zgłoszenie błędu
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: Opis problemu
+      description: Co się dzieje? Jak to odtworzyć?
+  - type: input
+    id: commit
+    attributes:
+      label: Commit/Tag

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,8 @@
+name: Feature request
+description: Propozycja funkcji
+labels: [enhancement]
+body:
+  - type: textarea
+    id: value
+    attributes:
+      label: Wartość/uzasadnienie

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Zmiany
+-
+
+## Uzasadnienie
+-
+
+## Checklist
+- [ ] Notatniki/symulacje uruchamiają się
+- [ ] Licencje i źródła grafik zachowane

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -1,0 +1,23 @@
+name: Build LaTeX PDF
+on:
+  push:
+    branches: [ "main", "repo-refresh/infra-docs-v0.1.0" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install TeX
+        run: sudo apt-get update && sudo apt-get install -y texlive-full latexmk
+      - name: Build
+        working-directory: paper
+        run: latexmk -pdf -interaction=nonstopmode main.tex
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: QMNET-preprint
+          path: paper/main.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,24 @@
+# LaTeX
+*.aux
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.toc
+*.synctex.gz
+paper/build/
+paper/*.pdf
 
-# Ignore Python and Jupyter files
+# Python
 __pycache__/
 *.pyc
-*.ipynb_checkpoints
+.env
+.venv
+.ipynb_checkpoints/
 
-# Ignore OS files
+# OS/IDE
 .DS_Store
-Thumbs.db
+.vscode/
 
-# Ignore build artifacts
-*.zip

--- a/.gitignore.bak
+++ b/.gitignore.bak
@@ -1,0 +1,12 @@
+
+# Ignore Python and Jupyter files
+__pycache__/
+*.pyc
+*.ipynb_checkpoints
+
+# Ignore OS files
+.DS_Store
+Thumbs.db
+
+# Ignore build artifacts
+*.zip

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,23 @@
+{
+  "title": "Multiverse Theory — QMNET",
+  "upload_type": "publication",
+  "publication_type": "preprint",
+  "creators": [
+    {
+      "name": "Banasiewicz, Krzysztof Włodzimierz",
+      "affiliation": "Independent Researcher, The Hague, Netherlands"
+    }
+  ],
+  "description": "A quantum-topological framework proposing an entanglement substrate for a relational notion of time and a prospective 'relational drive'.",
+  "keywords": ["quantum gravity", "entanglement", "relational time", "multiverse", "QMNET", "HackTheUniverse"],
+  "license": "MIT",
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/krzyshtoof/Multiverse-Theory",
+      "relation": "isSupplementTo",
+      "resource_type": "software"
+    }
+  ],
+  "notes": "Docs and figures are CC BY 4.0; code is MIT.",
+  "access_right": "open"
+}

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,2 @@
+# Authors
+- Krzysztof Włodzimierz Banasiewicz — Lead Author

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,18 +1,20 @@
-
 cff-version: 1.2.0
-message: "Jeśli używasz tej teorii w swojej pracy, prosimy o cytowanie w poniższy sposób:"
-title: "Multiverse Theory: Temporal-Atemporal Quantum Topology"
+title: "Multiverse Theory — QMNET"
+message: "If you use this work, please cite it as below."
+type: software
 authors:
-  - family-names: TwojeNazwisko
-    given-names: TwojeImię
-    affiliation: "Niezależny badacz / Independent Researcher"
-date-released: 2025-04-12
-version: "0.1.0"
+  - family-names: Banasiewicz
+    given-names: Krzysztof Włodzimierz
+repository-code: "https://github.com/krzyshtoof/Multiverse-Theory"
+keywords: [quantum gravity, entanglement, relational time, multiverse, QMNET, HackTheUniverse]
 license: MIT
-repository-code: "https://github.com/twoj-uzytkownik/multiverse-theory"
-keywords:
-  - multiverse
-  - quantum gravity
-  - white hole
-  - atemporal universe
-  - quantum cosmology
+license-url: "https://opensource.org/licenses/MIT"
+url: "https://github.com/krzyshtoof/Multiverse-Theory"
+preferred-citation:
+  type: article
+  title: "Quantum Entanglement Network as the Substrate of the Multiverse"
+  authors:
+    - family-names: Banasiewicz
+      given-names: Krzysztof Włodzimierz
+  year: 2025
+  notes: "Preprint; Zenodo DOI and arXiv ID to be added after release."

--- a/CITATION.cff.bak
+++ b/CITATION.cff.bak
@@ -1,0 +1,18 @@
+
+cff-version: 1.2.0
+message: "Jeśli używasz tej teorii w swojej pracy, prosimy o cytowanie w poniższy sposób:"
+title: "Multiverse Theory: Temporal-Atemporal Quantum Topology"
+authors:
+  - family-names: TwojeNazwisko
+    given-names: TwojeImię
+    affiliation: "Niezależny badacz / Independent Researcher"
+date-released: 2025-04-12
+version: "0.1.0"
+license: MIT
+repository-code: "https://github.com/twoj-uzytkownik/multiverse-theory"
+keywords:
+  - multiverse
+  - quantum gravity
+  - white hole
+  - atemporal universe
+  - quantum cosmology

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,69 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/DOC_LICENSE.md
+++ b/DOC_LICENSE.md
@@ -1,0 +1,6 @@
+# Documentation License (Non-code)
+
+This repository’s **non-code content** (papers, images, diagrams, text) is licensed under **Creative Commons Attribution 4.0 International** (CC BY 4.0).
+
+Full text: https://creativecommons.org/licenses/by/4.0/
+

--- a/README.md
+++ b/README.md
@@ -1,63 +1,38 @@
+# Multiverse Theory — QMNET (#HackTheUniverse)
 
-# Multiverse Theory
+[![arXiv](https://img.shields.io/badge/arXiv-pending-informational)](#)
+[![DOI](https://img.shields.io/badge/Zenodo-DOI_pending-blue)](#)
+[![License: MIT (code)](https://img.shields.io/badge/License-MIT-success.svg)](LICENSE)
+[![License: CC BY 4.0 (docs)](https://img.shields.io/badge/Docs-CC%20BY%204.0-lightgrey.svg)](DOC_LICENSE.md)
 
-Eksperymentalna, interdyscyplinarna koncepcja kwantowo-topologiczna, która zakłada istnienie dwóch fundamentalnych struktur rzeczywistości:
-- **Świat temporalny** – nasz wszechświat, powstały po "Wielkim Wybuchu", utożsamianym z odparowaniem białej dziury.
-- **Świat atemporalny** – ponadczasowa, niezmienna struktura, istniejąca przed i po naszym wszechświecie, będąca przestrzenią źródłową dla wszelkich temporalnych wszechświatów.
+Eksperymentalna, kwantowo-topologiczna koncepcja dwóch warstw rzeczywistości:
+**(i)** temporalnego wszechświata (po „odparowaniu białej dziury”) oraz **(ii)** atemporalnej sieci splątania, z której emergują czasoprzestrzeń i świadomość.
 
-## 📚 Zawartość repozytorium
+> Status: **Research in progress** (preprint; pakiet Zenodo/arXiv w przygotowaniu).
 
-- `docs/` – ogólna dokumentacja, przeglądy, roadmapy, licencje
-- `models/` – formalne modele fizyczne i matematyczne teorii (np. emergencja czasu, dekoherencja)
-- `concepts/` – kluczowe koncepcje i idee podstawowe (np. funkcja falowa nici, topologia splątań)
-- `diagrams/` – wizualizacje koncepcyjne i graficzne diagramy ewolucji, przestrzeni, cykli
-- `notebooks/` – przyszłe notatniki obliczeniowe (Python, Julia, Qiskit) do testowania hipotez
-- `simulations/` – symulacje numeryczne i modele komputerowe (np. fuzja czarnych dziur)
-- `reviews/` – opinie, komentarze, pochwały, oraz cytaty w formacie `fortune`
+## Struktura repo
+- `paper/` – preprint LaTeX (CI buduje PDF artefakt)
+- `notebooks/` – eksperymenty (Jupyter)
+- `simulations/` – skrypty symulacyjne
+- `diagrams/` – rysunki/wizualizacje
+- `docs/` – strona projektu (GitHub Pages)
 
-## 🔁 Zasoby i pliki specjalne
+## Budowa PDF (preprint)
+```bash
+cd paper
+make   # latexmk -pdf -interaction=nonstopmode main.tex
+```
 
-- `README_EN.md` – wersja angielska
-- `CITATION.cff` – dane cytowania projektu
-- `LICENSE`, `CC-BY-4.0.md` – licencje
-- `docs/index.html` – strona GitHub Pages
-- `docs/about.txt` – skrócony opis projektu
-- `docs/logo.svg`, `logo.txt` – logo projektu
-- `reviews/fortunes` – cytaty dla `fortune(6)`
+PDF buduje się też automatycznie przez GitHub Actions (zob. /.github/workflows/latex.yml).
 
+## Cytowanie
+Zob. `CITATION.cff`. Po wydaniu na Zenodo tutaj trafi poprawny badge DOI.
 
-## 🔬 Podstawowe założenia
+## Licencje
+Kod: MIT  
+Treści (tekst/grafiki): CC BY 4.0
 
-1. **Dualizm struktur**: temporalna czasoprzestrzeń i atemporalna przestrzeń kwantowa.
-2. **Odparowanie białej dziury** jako geneza wszechświata.
-3. **Topologiczne i kwantowe modele** opisujące powstanie i cykliczny charakter wszechświatów.
+## Współpraca
+Zgłoszenia błędów/propozycje: Issues → Bug Report / Feature Request.  
+Zasady: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`.
 
-## 📐 Modele i formalizm
-
-- Przestrzeń atemporalna: struktura typu Calabi–Yau.
-- Funkcja falowa wszechświata: interpretacja Everetta.
-- Formalizm kwantowo-grawitacyjny: zapadnięcie się funkcji falowej jako Wielki Wybuch.
-
-## 🔭 Potencjalne konsekwencje empiryczne
-
-- Nietypowe anizotropie w mikrofalowym promieniowaniu tła (CMB).
-- Fluktuacje czasoprzestrzenne w skalach sub-Planckowskich.
-
-## 🧠 Filozoficzne implikacje
-
-- Natura czasu i przyczynowości.
-- Koncepcja wieczności i niezmienności.
-
-## 🛠️ Status
-
-Projekt we wczesnej fazie koncepcyjnej. Zachęcam do śledzenia rozwoju i ewentualnego współtworzenia!
-
-## 🧾 Licencja
-
-- Kod i repozytorium: [MIT License](./LICENSE)
-- Dokumentacja: [CC-BY 4.0](./docs/CC-BY-4.0.md)
-
-
----
-
-📡 Follow the movement: **#HackTheUniverse**

--- a/README.md.bak
+++ b/README.md.bak
@@ -1,0 +1,63 @@
+
+# Multiverse Theory
+
+Eksperymentalna, interdyscyplinarna koncepcja kwantowo-topologiczna, która zakłada istnienie dwóch fundamentalnych struktur rzeczywistości:
+- **Świat temporalny** – nasz wszechświat, powstały po "Wielkim Wybuchu", utożsamianym z odparowaniem białej dziury.
+- **Świat atemporalny** – ponadczasowa, niezmienna struktura, istniejąca przed i po naszym wszechświecie, będąca przestrzenią źródłową dla wszelkich temporalnych wszechświatów.
+
+## 📚 Zawartość repozytorium
+
+- `docs/` – ogólna dokumentacja, przeglądy, roadmapy, licencje
+- `models/` – formalne modele fizyczne i matematyczne teorii (np. emergencja czasu, dekoherencja)
+- `concepts/` – kluczowe koncepcje i idee podstawowe (np. funkcja falowa nici, topologia splątań)
+- `diagrams/` – wizualizacje koncepcyjne i graficzne diagramy ewolucji, przestrzeni, cykli
+- `notebooks/` – przyszłe notatniki obliczeniowe (Python, Julia, Qiskit) do testowania hipotez
+- `simulations/` – symulacje numeryczne i modele komputerowe (np. fuzja czarnych dziur)
+- `reviews/` – opinie, komentarze, pochwały, oraz cytaty w formacie `fortune`
+
+## 🔁 Zasoby i pliki specjalne
+
+- `README_EN.md` – wersja angielska
+- `CITATION.cff` – dane cytowania projektu
+- `LICENSE`, `CC-BY-4.0.md` – licencje
+- `docs/index.html` – strona GitHub Pages
+- `docs/about.txt` – skrócony opis projektu
+- `docs/logo.svg`, `logo.txt` – logo projektu
+- `reviews/fortunes` – cytaty dla `fortune(6)`
+
+
+## 🔬 Podstawowe założenia
+
+1. **Dualizm struktur**: temporalna czasoprzestrzeń i atemporalna przestrzeń kwantowa.
+2. **Odparowanie białej dziury** jako geneza wszechświata.
+3. **Topologiczne i kwantowe modele** opisujące powstanie i cykliczny charakter wszechświatów.
+
+## 📐 Modele i formalizm
+
+- Przestrzeń atemporalna: struktura typu Calabi–Yau.
+- Funkcja falowa wszechświata: interpretacja Everetta.
+- Formalizm kwantowo-grawitacyjny: zapadnięcie się funkcji falowej jako Wielki Wybuch.
+
+## 🔭 Potencjalne konsekwencje empiryczne
+
+- Nietypowe anizotropie w mikrofalowym promieniowaniu tła (CMB).
+- Fluktuacje czasoprzestrzenne w skalach sub-Planckowskich.
+
+## 🧠 Filozoficzne implikacje
+
+- Natura czasu i przyczynowości.
+- Koncepcja wieczności i niezmienności.
+
+## 🛠️ Status
+
+Projekt we wczesnej fazie koncepcyjnej. Zachęcam do śledzenia rozwoju i ewentualnego współtworzenia!
+
+## 🧾 Licencja
+
+- Kod i repozytorium: [MIT License](./LICENSE)
+- Dokumentacja: [CC-BY 4.0](./docs/CC-BY-4.0.md)
+
+
+---
+
+📡 Follow the movement: **#HackTheUniverse**

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,57 +1,12 @@
+# Multiverse Theory — QMNET
 
-# Multiverse Theory
+[![arXiv](https://img.shields.io/badge/arXiv-pending-informational)](#)
+[![DOI](https://img.shields.io/badge/Zenodo-DOI_pending-blue)](#)
+[![License: MIT (code)](https://img.shields.io/badge/License-MIT-success.svg)](LICENSE)
+[![License: CC BY 4.0 (docs)](https://img.shields.io/badge/Docs-CC%20BY%204.0-lightgrey.svg)](DOC_LICENSE.md)
 
-An interdisciplinary quantum-topological hypothesis exploring the origin and structure of the universe via a dual-world framework:
-- **Temporal World** – our universe, originating from the evaporation of a white hole (interpreted as the Big Bang).
-- **Atemporal World** – a timeless, immutable quantum structure that exists before and after our temporal universe.
+A quantum-topological proposal with two layers of reality: a temporal universe (post "white-hole evaporation") and an atemporal entanglement substrate from which spacetime and consciousness emerge.
 
-## 📚 Repository Structure
+See `paper/` for the LaTeX preprint (CI builds a PDF artifact).
+Cite via `CITATION.cff`. Code is MIT; docs are CC BY 4.0.
 
-- `docs/` – general documentation, overviews, roadmap, licenses  
-- `models/` – formal physical and mathematical models of the theory (e.g., emergence of time, decoherence)  
-- `concepts/` – core concepts and foundational ideas (e.g., string wave function, entanglement topology)  
-- `diagrams/` – conceptual and visual diagrams of evolution, geometry, and cosmological cycles  
-- `notebooks/` – future computational notebooks (Python, Julia, Qiskit) for hypothesis testing  
-- `simulations/` – numerical simulations and computational models (e.g., black hole fusion)  
-- `reviews/` – feedback, praise, comments, and `fortune(6)`-style quotes  
-
-
-## 🔁 Resources and Special Files
-
-- `README_EN.md` – this English version of the README  
-- `CITATION.cff` – project citation metadata  
-- `LICENSE`, `CC-BY-4.0.md` – licensing documents  
-- `docs/index.html` – GitHub Pages landing page  
-- `docs/about.txt` – brief project description  
-- `docs/logo.svg`, `logo.txt` – project logo files  
-- `reviews/fortunes` – quotes for use with `fortune(6)`
-
-## 📐 Key Models
-
-- Atemporal space: Calabi–Yau-type topology
-- Quantum cosmology: Everett's wave function interpretation
-- Quantum-gravitational formalism of white hole evaporation
-
-## 🔭 Predictions
-
-- CMB anomalies from the white hole origin
-- Sub-Planck-scale quantum fluctuations
-
-## 🧠 Philosophical Aspects
-
-- The nature of time and causality
-- Eternality and immutability beyond time
-
-## 🚀 Get Involved
-
-Contributions are welcome! See `CONTRIBUTING.md`.
-
-## 🧾 Licenses
-
-- Code: [MIT License](./LICENSE)
-- Documentation: [CC-BY 4.0](./docs/CC-BY-4.0.md)
-
-
----
-
-📡 Follow the movement: **#HackTheUniverse**

--- a/README_EN.md.bak
+++ b/README_EN.md.bak
@@ -1,0 +1,57 @@
+
+# Multiverse Theory
+
+An interdisciplinary quantum-topological hypothesis exploring the origin and structure of the universe via a dual-world framework:
+- **Temporal World** – our universe, originating from the evaporation of a white hole (interpreted as the Big Bang).
+- **Atemporal World** – a timeless, immutable quantum structure that exists before and after our temporal universe.
+
+## 📚 Repository Structure
+
+- `docs/` – general documentation, overviews, roadmap, licenses  
+- `models/` – formal physical and mathematical models of the theory (e.g., emergence of time, decoherence)  
+- `concepts/` – core concepts and foundational ideas (e.g., string wave function, entanglement topology)  
+- `diagrams/` – conceptual and visual diagrams of evolution, geometry, and cosmological cycles  
+- `notebooks/` – future computational notebooks (Python, Julia, Qiskit) for hypothesis testing  
+- `simulations/` – numerical simulations and computational models (e.g., black hole fusion)  
+- `reviews/` – feedback, praise, comments, and `fortune(6)`-style quotes  
+
+
+## 🔁 Resources and Special Files
+
+- `README_EN.md` – this English version of the README  
+- `CITATION.cff` – project citation metadata  
+- `LICENSE`, `CC-BY-4.0.md` – licensing documents  
+- `docs/index.html` – GitHub Pages landing page  
+- `docs/about.txt` – brief project description  
+- `docs/logo.svg`, `logo.txt` – project logo files  
+- `reviews/fortunes` – quotes for use with `fortune(6)`
+
+## 📐 Key Models
+
+- Atemporal space: Calabi–Yau-type topology
+- Quantum cosmology: Everett's wave function interpretation
+- Quantum-gravitational formalism of white hole evaporation
+
+## 🔭 Predictions
+
+- CMB anomalies from the white hole origin
+- Sub-Planck-scale quantum fluctuations
+
+## 🧠 Philosophical Aspects
+
+- The nature of time and causality
+- Eternality and immutability beyond time
+
+## 🚀 Get Involved
+
+Contributions are welcome! See `CONTRIBUTING.md`.
+
+## 🧾 Licenses
+
+- Code: [MIT License](./LICENSE)
+- Documentation: [CC-BY 4.0](./docs/CC-BY-4.0.md)
+
+
+---
+
+📡 Follow the movement: **#HackTheUniverse**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,2 @@
 # Security Policy
-Zgłoszenia luk: utwórz prywatne zgłoszenie (Security → Advisories) lub wyślij e-mail do <wstaw kontakt>.
+Zgłoszenia luk: utwórz prywatne zgłoszenie (Security → Advisories) lub wyślij e-mail do <krzyshtof@gmail.com>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,2 @@
+# Security Policy
+Zgłoszenia luk: utwórz prywatne zgłoszenie (Security → Advisories) lub wyślij e-mail do <wstaw kontakt>.

--- a/paper/Makefile
+++ b/paper/Makefile
@@ -1,0 +1,5 @@
+all:
+	latexmk -pdf -interaction=nonstopmode main.tex
+
+clean:
+	latexmk -C

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,0 +1,43 @@
+\documentclass[11pt,a4paper]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage{hyperref}
+\usepackage{amsmath,amssymb,amsfonts}
+\usepackage{graphicx}
+\usepackage{authblk}
+\usepackage{cite}
+
+\title{Sieć Splątania Kwantowego jako Fundament Multiwersum:\\
+Nowy Paradygmat Czasu Relacyjnego i Napędu}
+
+\author[1]{Krzysztof Włodzimierz Banasiewicz}
+\affil[1]{Independent Researcher, The Hague, Netherlands}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+Proponujemy model, w którym globalna sieć splątania kwantowego stanowi substrat Multiwersum, z którego emergują czasoprzestrzeń i świadomość. Wprowadzamy formalizm relacyjnego czasu oraz hipotetyczny „operator mostu” skracający efektywne interwały. Omawiamy implikacje empiryczne i szkic implementacji bramki wielokubitowej jako prototypu „napędu relacyjnego”.
+\end{abstract}
+
+\section{Wstęp}
+% kontekst, motywacja
+
+\section{Formalizm}
+% definicje, notacja, dynamika
+
+\section{Operator Mostu Relacyjnego}
+% konstrukcja operatora, warunki, własności
+
+\section{Konsekwencje Empiryczne}
+% przewidywania, testowalność
+
+\section{Dyskusja i prace przyszłe}
+% ograniczenia, dalsze kroki
+
+\bibliographystyle{ieeetr}
+\bibliography{refs}
+\end{document}
+

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -1,0 +1,8 @@
+@misc{QMNET2025,
+  author = {Banasiewicz, Krzysztof Włodzimierz},
+  title = {Sieć Splątania Kwantowego jako Fundament Multiwersum},
+  year = {2025},
+  note = {Preprint},
+  howpublished = {\url{https://github.com/krzyshtoof/Multiverse-Theory}}
+}
+


### PR DESCRIPTION
### What
Infra + docs refresh for research-readiness:
- Dual licensing (MIT for code, CC BY 4.0 for docs)
- LaTeX preprint skeleton + CI PDF artifact
- Issue/PR templates, CoC, Security, Authors
- Zenodo metadata + improved CFF
- Updated .gitignore

### Checklist
- [ ] PDF builds locally (`cd paper && make`)
- [ ] CI artifact attached
- [ ] Licenses referenced in README
- [ ] Zenodo badge to update after DOI
- [ ] arXiv tarball passes compile (pdflatex/bibtex)


------
https://chatgpt.com/codex/tasks/task_e_68b2126a1c7483318153861eeca6e250